### PR TITLE
Add direct styling support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This HTML5 custom element attempts to replicate WebTV's exclusive `<audioscope>`
 ## Usage
 
 1. Replace all instances of `<audioscope>` with `<webtv-audioscope>` (this step may be made optional in the future)
-2. Add `<script src="https://cdn.jsdelivr.net/gh/Sgeo/webtv-audioscope@1.0/webtv-audioscope.js"></script>` to the `<head></head>` of the page
+2. Add `<script src="https://cdn.jsdelivr.net/gh/Sgeo/webtv-audioscope@1.2/webtv-audioscope.js"></script>` to the `<head></head>` of the page
 3. Ensure all `<webtv-audioscope>` tags are properly closed.
 4. Replace audio on the page, such as `<bgsound>` and `<a>` links to audio files with `<audio>` elements. I suggest using `<audio controls>`. The music may also need to be rendered to .mp3 or other audio format that modern browsers can play. `<webtv-audioscope>` does not yet work with other Web Audio reliant players, this may be added in the future.
 
@@ -21,4 +21,3 @@ This HTML5 custom element attempts to replicate WebTV's exclusive `<audioscope>`
 * Currently unsupported attributes:
     * align
     * maxlevel
-* width and height can currently only be set to pixel values


### PR DESCRIPTION
Also added support for adding an ID/class to the canvas (although it isn't terribly useful since CSS can't modify shadow DOM styles) and fixed a typo on line 16 ("GlobalApha" instead of "GlobalAlpha".)

Should close issues #6 and #7 (although the implementation for the latter issue isn't perfect - if the page inside the iframe has the audioscope script as well as the parent page, they will conflict and cause issues attaching the event listeners.)